### PR TITLE
Send full reducer payload to OpenChannel start msg

### DIFF
--- a/OpenChannel.js
+++ b/OpenChannel.js
@@ -3324,7 +3324,10 @@ var OpenchannelConversation = function OpenchannelConversation(props) {
       if (channel && channelUrl === channel.url) {
         messagesDispatcher({
           type: SENDING_MESSAGE_START,
-          payload: message
+          payload: {
+            channel,
+            message,
+          },
         });
       }
     }));


### PR DESCRIPTION
First of all, thanks for the work done on this library!

# Motivation

The motivation behind this PR was a possible bug that I found when trying to customize the `UIKIT` => `OpenChannel` via `renderMessageInput`. There's no UIKIT documentation specifically for `OpenChannel` `renderMessageInput`, so I dig into the code and I also compared with the existing documentation for the same `renderMessageInput` but for the `GroupChannel. With these findings I could get to a code similar to this one:

```jsx
const MyChat = () => {
  const state = useSendbirdStateContext();
  const sdk = sendBirdSelectors.getSdk(state);
  const sendOpenChannelUserMessage = sendBirdSelectors.getOpenChannelSendUserMessage(state);

  const renderMessageInput = ({disabled, user}) => {
    const sendMessage = (message) => {
      const params = new sdk.UserMessageParams();
      params.message = message;
      return sendOpenChannelUserMessage(channelUrl, params);
    };

    return <ChatInput sendMessage={sendMessage} disabled={disabled} user={user} />;
  };

  return (
    <SendBirdProvider appId={API_KEY} nickname={login} theme="dark" userId={userId}>
      <OpenChannel channelUrl={channelUrl} renderMessageInput={renderMessageInput} />
    </SendBirdProvider>
  );
}
```

With this code I could render my Chat just fine and I could also send the message, but as soon as the send happens, something in UIKIT calls a re-render and this was causing the following error:

```
OpenChannel.js:1789 Uncaught TypeError: Cannot read property 'url' of undefined
    at reducer (main-c952669a9e9929a63411.js:201836)
    at updateReducer (main-c952669a9e9929a63411.js:140813)
    at Object.useReducer (main-c952669a9e9929a63411.js:141597)
    at useReducer (main-c952669a9e9929a63411.js:168873)
    at OpenchannelConversation (main-c952669a9e9929a63411.js:203250)
    at renderWithHooks (main-c952669a9e9929a63411.js:140489)
    at updateFunctionComponent (main-c952669a9e9929a63411.js:142668)
    at beginWork (main-c952669a9e9929a63411.js:144195)
    at HTMLUnknownElement.callCallback (main-c952669a9e9929a63411.js:125881)
    at Object.invokeGuardedCallbackDev (main-c952669a9e9929a63411.js:125930)
```

I dig into the code again and I found that there's a single occurrence of `SENDING_MESSAGE_START` that was being sent without the `channel` as part of the payload. This way this PR is to fix this reduce action to send the same payload as it's being already sent by other places in the code that dispatches the same action.

Please let me know if this is enough info.

# Changes

- [x] Send full reducer payload to OpenChannel start msg